### PR TITLE
Removal of the Subtlemessage & Narrate Sanitization

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -52,7 +52,7 @@
 		src << "Only administrators may use this command."
 		return
 
-	var/msg = sanitize(input("Message:", text("Subtle PM to [M.key]")) as text)
+	var/msg = input("Message:", text("Subtle PM to [M.key]")) as text
 
 	if (!msg)
 		return
@@ -109,7 +109,7 @@
 		src << "Only administrators may use this command."
 		return
 
-	var/msg = sanitize(input("Message:", text("Enter the text you wish to appear to everyone:")) as text)
+	var/msg = input("Message:", text("Enter the text you wish to appear to everyone:")) as text
 
 	if (!msg)
 		return
@@ -132,7 +132,7 @@
 	if(!M)
 		return
 
-	var/msg = sanitize(input("Message:", text("Enter the text you wish to appear to your target:")) as text)
+	var/msg = input("Message:", text("Enter the text you wish to appear to your target:")) as text
 
 	if( !msg )
 		return


### PR DESCRIPTION
Basicly allows you to do html formatting in direct narrates, subtle messages, and global narrates.
Useful for story telling with style.

This does allow some html injection but if you don't trust your admins then why are they staff, right?
Messages are logged anyway.